### PR TITLE
fix: do not look for tapes in dirs recursively

### DIFF
--- a/src/tape-store.ts
+++ b/src/tape-store.ts
@@ -42,8 +42,6 @@ export default class TapeStore {
         } catch (e) {
           this.context.logger.error(`Error reading tape ${fullPath}\n${e.toString()}`);
         }
-      } else {
-        this.loadTapesAtDir(`${fullPath}/`);
       }
     }
   }


### PR DESCRIPTION
This enables having subdirs in main tapes dir (for example, to use tapes from subdirs in specific cases)